### PR TITLE
Fix typo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ Coming later. The API is somewhat similar to the Rust version (https://docs.rs/a
 
 ### Node
 
-Run with `wasm-pack build --target nodejs && node example/flights.js`.
+Run with `wasm-pack build --target nodejs && node examples/flights.js`.
 
 To use a debug build, run `wasm-pack build --target nodejs --dev && node examples/flights.js`.
 


### PR DESCRIPTION
There were two `example` typos there. Marc's patch fixed the first, this fixes the second one :)